### PR TITLE
ol-geocoder@5.0.6/dist doesn’t work with Openlayers v7.4.0

### DIFF
--- a/src/nominatim.js
+++ b/src/nominatim.js
@@ -2,7 +2,7 @@ import LayerVector from 'ol/layer/Vector';
 import SourceVector from 'ol/source/Vector';
 import Point from 'ol/geom/Point';
 import Feature from 'ol/Feature';
-import proj from 'ol/proj';
+import { transform, transformExtent } from 'ol/proj';
 
 import { VARS, TARGET_TYPE, PROVIDERS, EVENT_TYPE } from '../konstants';
 
@@ -207,13 +207,13 @@ export class Nominatim {
     const map = this.Base.getMap();
     const coord_ = [Number.parseFloat(place.lon), Number.parseFloat(place.lat)];
     const projection = map.getView().getProjection();
-    const coord = proj.transform(coord_, 'EPSG:4326', projection);
+    const coord = transform(coord_, 'EPSG:4326', projection);
 
     let { bbox } = place;
 
     if (bbox) {
-      bbox = proj.transformExtent(
-        [bbox[2], bbox[1], bbox[3], bbox[0]], // NSWE -> WSEN
+      bbox = transformExtent(
+        [bbox[2], bbox[0], bbox[3], bbox[1]], // SNWE -> WSEN
         'EPSG:4326',
         projection
       );


### PR DESCRIPTION
I propose 2 changes in the same pull :

1/ There is a bug in receiving the place bounding : The nominatim doc specify min latitude, max latitude, min longitude, max longitude which means SNWE https://nominatim.org/release-docs/latest/api/Output/#boundingbox src/nominatim.js line 216 read NSWE, which is wrong 216: [bbox[2], bbox[1], bbox[3], bbox[0]] would be [bbox[2], bbox[0], bbox[3], bbox[1]]

This is Ok with Openlayers up to 7.3.0 that accept negative outbounds but not anymore for ^7.4.0 We now need to do this correction

2/ In nominatim.js, the ol/proj import is too generic line 5: import proj from 'ol/proj';
should be: import { transform, transformExtent } from 'ol/proj';

First, this is more logical & reduce the imported code to the minimum Second, this is blocking to import ol-geocoder in a project as modules rather than the final bundle