### PR TITLE
fix: update osm url due to api change

### DIFF
--- a/src/providers/osm.js
+++ b/src/providers/osm.js
@@ -7,7 +7,7 @@ export class OpenStreet {
    */
   constructor() {
     this.settings = {
-      url: 'https://nominatim.openstreetmap.org/search/',
+      url: 'https://nominatim.openstreetmap.org/search',
 
       params: {
         q: '',


### PR DESCRIPTION
Apparently, there has been a change in the API for Open Street Map.
With their recent update, the trailing slash in their API endpoint is no longer required.

As a result, a search will now trigger a 404 error with a message like: "Error! No internet connection?"

fix https://github.com/mostafaznv/nova-map-field/issues/41